### PR TITLE
Add RM Paper Pro Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,36 @@
-BINARY=dist/rmfakecloud-proxy
-WINBINARY=dist/rmfakecloud-proxy.exe
-LINUXBINARY=dist/rmfakecloud-proxy64
-INSTALLER=dist/installer.sh
+ARMV7_BINARY=dist/rmfakecloud-proxy-arm7
+AARCH64_BINARY=dist/rmfakecloud-proxy-aarch64
+WIN_BINARY=dist/rmfakecloud-proxy.exe
+LINUX_BINARY=dist/rmfakecloud-proxy64
+RM12_INSTALLER=dist/installer-rm12.sh
+RMPRO_INSTALLER=dist/installer-rmpro.sh
 .PHONY: clean
-all: $(INSTALLER) $(WINBINARY) $(LINUXBINARY)
+all: $(RMPRO_INSTALLER) $(RM12_INSTALLER) $(WIN_BINARY) $(LINUX_BINARY)
 
-$(LINUXBINARY): version.go main.go
+$(LINUX_BINARY): version.go main.go
 	go build -ldflags="-w -s" -o $@
 
-$(BINARY): version.go main.go
+$(ARMV7_BINARY): version.go main.go
 	GOARCH=arm GOARM=7 go build -ldflags="-w -s" -o $@
 
-$(WINBINARY): version.go main.go
+$(AARCH64_BINARY): version.go main.go
+	GOARCH=arm64 go build -ldflags="-w -s" -o $@
+
+$(WIN_BINARY): version.go main.go
 	GOOS=windows go build -ldflags="-w -s" -o $@
 
-version.go: 
+version.go:
 	go generate
 
-$(INSTALLER): $(BINARY) scripts/installer.sh
+$(RMPRO_INSTALLER): $(AARCH64_BINARY) scripts/installer.sh
 	cp scripts/installer.sh $@
-	gzip -c $(BINARY) >> $@
+	gzip -c $(AARCH64_BINARY) >> $@
 	chmod +x $@
+
+$(RM12_INSTALLER): $(ARMV7_BINARY) scripts/installer.sh
+	cp scripts/installer.sh $@
+	gzip -c $(ARMV7_BINARY) >> $@
+	chmod +x $@
+
 clean:
 	rm -fr dist

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@ ARMV7_BINARY=dist/rmfakecloud-proxy-arm7
 AARCH64_BINARY=dist/rmfakecloud-proxy-aarch64
 WIN_BINARY=dist/rmfakecloud-proxy.exe
 LINUX_BINARY=dist/rmfakecloud-proxy64
+INSTALLER=dist/installer.sh
 RM12_INSTALLER=dist/installer-rm12.sh
 RMPRO_INSTALLER=dist/installer-rmpro.sh
 .PHONY: clean
-all: $(RMPRO_INSTALLER) $(RM12_INSTALLER) $(WIN_BINARY) $(LINUX_BINARY)
+all: $(RMPRO_INSTALLER) $(RM12_INSTALLER) $(INSTALLER) $(WIN_BINARY) $(LINUX_BINARY)
 
 $(LINUX_BINARY): version.go main.go
 	go build -ldflags="-w -s" -o $@
@@ -27,7 +28,7 @@ $(RMPRO_INSTALLER): $(AARCH64_BINARY) scripts/installer.sh
 	gzip -c $(AARCH64_BINARY) >> $@
 	chmod +x $@
 
-$(RM12_INSTALLER): $(ARMV7_BINARY) scripts/installer.sh
+$(INSTALLER) $(RM12_INSTALLER): $(ARMV7_BINARY) scripts/installer.sh
 	cp scripts/installer.sh $@
 	gzip -c $(ARMV7_BINARY) >> $@
 	chmod +x $@


### PR DESCRIPTION
This updates the Makefile to generate the `aarch64` binary and an installer for it. This takes care of the [Discord support thread's](https://discord.com/channels/385916768696139794/1291153354579247267) problem of having the wrong architecture binary.

I suppose the next step would be to update the `automagic.sh` script in the main repo.

I was able to test this against my server and the pairing code worked, but nothing else is, but I'm not sure that has anything to do with the changes here.