### PR TITLE
Allow for non-tls proxy

### DIFF
--- a/main.go
+++ b/main.go
@@ -163,10 +163,25 @@ func _main() error {
 		close(done)
 	}()
 
-	log.Printf("cert-file=%s key-file=%s listen-addr=%s upstream-url=%s", cfg.CertFile, cfg.KeyFile, srv.Addr, upstream.String())
-	if err := srv.ListenAndServeTLS(cfg.CertFile, cfg.KeyFile); err != http.ErrServerClosed {
-		return fmt.Errorf("ListenAndServeTLS: %v", err)
-	}
+        if cfg.CertFile != "" && cfg.KeyFile != "" {
+          log.Printf("cert-file=%s key-file=%s listen-addr=%s upstream-url=%s", cfg.CertFile, cfg.KeyFile, srv.Addr, upstream.String())
+          if err := srv.ListenAndServeTLS(cfg.CertFile, cfg.KeyFile); err != http.ErrServerClosed {
+                  return fmt.Errorf("ListenAndServeTLS: %v", err)
+          }
+        } else {
+          if cfg.CertFile == "" && cfg.KeyFile == "" {
+            log.Printf("No cert or key specified, launching as http server: listen-addr=%s upstream-url=%s", srv.Addr, upstream.String())
+          } else if cfg.CertFile != "" {
+            log.Printf("No cert, launching as http server: listen-addr=%s upstream-url=%s", srv.Addr, upstream.String())
+          } else {
+            log.Printf("No key specified, launching as http server: listen-addr=%s upstream-url=%s", srv.Addr, upstream.String())
+          }
+
+          if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+                  return fmt.Errorf("ListenAndServe: %v", err)
+          }
+        }
+
 
 	<-done
 	return nil


### PR DESCRIPTION
I added rough support for the having a non-tls proxy, including logging why it is not doing tls.

The reason why I added this is because in my case I am using tailscale to connect to my server, which goes through an encrypted tunnel, so setting up this to be https was redundant.

For safety we might want to put it behind a cli option so if the cert isn't there it will fail to do tls instead of just not doing so.

I can implement the cli flag, I was just wanted to gauge interest before I put too much work into it.

Thank you for your time.