### PR TITLE
Add eu.tectonic.remarkable.com

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -171,6 +171,7 @@ function patch_hosts(){
 127.0.0.1 my.remarkable.com
 127.0.0.1 ping.remarkable.com
 127.0.0.1 internal.cloud.remarkable.com
+127.0.0.1 eu.tectonic.remarkable.com
 127.0.0.1 backtrace-proxy.cloud.remarkable.engineering
 127.0.0.1 dev.ping.remarkable.com
 127.0.0.1 dev.tectonic.remarkable.com


### PR DESCRIPTION
This domain is required by the SW 3.20 and needed for 3.19 with the latest rmfakecloud. See https://github.com/ddvk/rmfakecloud/pull/364